### PR TITLE
Fixed display issue reported in issue #27

### DIFF
--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -26,7 +26,6 @@
     var TIME_FORMAT = "{{ time_format }}";
     var DATETIME_FORMAT = "{{ datetime_format }}";
 </script>
-<script type="text/javascript" src="{% url 'jet:jsi18n' %}"></script>
 <script src="{% static "jet/js/build/bundle.min.js" as url %}{{ url|jet_append_version }}"></script>
 
 {% jet_static_translation_urls as translation_urls %}
@@ -35,6 +34,7 @@
 {% endfor %}
 
 {% block extrahead %}{% endblock %}
+<script type="text/javascript" src="{% url 'jet:jsi18n' %}"></script>
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE" />{% endblock %}
 </head>
 {% load i18n %}


### PR DESCRIPTION
I reported issue #27 which turned out to be a wider problem in how tabs are displayed in change_form views and how select2 fields are displayed. It appears that all what was needed to fix this was the load order of jsi18n.js. The pull request moves jsi18n.js so that it loads after all the js files loaded by django.