### PR TITLE
Fix empty href with permissions

### DIFF
--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -26,7 +26,6 @@
     var TIME_FORMAT = "{{ time_format }}";
     var DATETIME_FORMAT = "{{ datetime_format }}";
 </script>
-<script type="text/javascript" src="{% url 'jet:jsi18n' %}"></script>
 <script src="{% static "jet/js/build/bundle.min.js" as url %}{{ url|jet_append_version }}"></script>
 
 {% jet_static_translation_urls as translation_urls %}
@@ -35,6 +34,7 @@
 {% endfor %}
 
 {% block extrahead %}{% endblock %}
+<script type="text/javascript" src="{% url 'jet:jsi18n' %}"></script>
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE" />{% endblock %}
 </head>
 {% load i18n %}

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -82,7 +82,7 @@ def get_app_list(context, order=True):
                     'perms': perms,
                     'model_name': model._meta.model_name
                 }
-                if perms.get('change', False):
+                if perms.get('view', False):
                     try:
                         model_dict['admin_url'] = reverse('admin:%s_%s_changelist' % info, current_app=admin_site.name)
                     except NoReverseMatch:


### PR DESCRIPTION
When setting permissions on a menu entry to view only, Django jet creates the menu item but the href attribute is set to "None". This is caused by the fact that the model's changelist url is reversed only if the permission is "change". Using "view" instead of "change" as the criteria to get the changelist url is sufficient to generate correct menu urls for whether the permission is "change" or "view" or both. 

Thank you for considering this pull request and thank you even more for your efforts to reboot django-jet.