### PR TITLE
Initialize jQuery

### DIFF
--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -26,6 +26,10 @@
     var TIME_FORMAT = "{{ time_format }}";
     var DATETIME_FORMAT = "{{ datetime_format }}";
 </script>
+<!-- Initialize jquery in order to avoid issues with django.jQuery on the console -->
+<script src="{% static 'admin/js/vendor/jquery/jquery.min.js' %}"></script>
+<script src="{% static 'admin/js/jquery.init.js' %}"></script>
+<!-- End of initialization -->
 <script type="text/javascript" src="{% url 'jet:jsi18n' %}"></script>
 <script src="{% static "jet/js/build/bundle.min.js" as url %}{{ url|jet_append_version }}"></script>
 


### PR DESCRIPTION
Seems there's an issue with django.jQuery . Initializing jQuery from admin vendor eliminates this issue.