### PR TITLE
docs: fix simple typo, dictinaries -> dictionaries

### DIFF
--- a/jet/dashboard/modules.py
+++ b/jet/dashboard/modules.py
@@ -222,7 +222,7 @@ class LinkList(DashboardModule):
     #: Links are contained in ``children`` attribute which you can pass as constructor parameter
     #: to make your own preinstalled link lists.
     #:
-    #: ``children`` is an array of dictinaries::
+    #: ``children`` is an array of dictionaries::
     #:
     #:     [
     #:          {


### PR DESCRIPTION
There is a small typo in jet/dashboard/modules.py.

Should read `dictionaries` rather than `dictinaries`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md