### PR TITLE
Fix render method AccessTokenWidget

### DIFF
--- a/jet/dashboard/dashboard_modules/yandex_metrika.py
+++ b/jet/dashboard/dashboard_modules/yandex_metrika.py
@@ -100,7 +100,7 @@ class YandexMetrikaClient:
 class AccessTokenWidget(Widget):
     module = None
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value and len(value) > 0:
             link = '<a href="%s">%s</a>' % (
                 reverse('jet-dashboard:yandex-metrika-revoke', kwargs={'pk': self.module.model.pk}),


### PR DESCRIPTION
Issue #75
TypeError at /jet/dashboard/module/21/
AccessTokenWidget.render() got an unexpected keyword argument 'renderer'

when uses yandex metrika and click to login
![image](https://user-images.githubusercontent.com/85240536/218749628-0ea651ca-e542-4d4e-aaeb-b311fb5e5e93.png)
<img width="769" alt="image" src="https://user-images.githubusercontent.com/85240536/218749683-122c3508-ba6c-4d24-8c84-1ce3790ce304.png">


needs to add rendered=None to render function class AccessTokenWidget