### PR TITLE
Remove unneeded style for action-counter

### DIFF
--- a/jet/static/jet/css/_changelist.scss
+++ b/jet/static/jet/css/_changelist.scss
@@ -383,10 +383,6 @@
       }
     }
 
-    span.all, span.action-counter, span.clear, span.question {
-      display: none;
-    }
-
     span.clear {
       margin-left: 5px;
     }


### PR DESCRIPTION
https://github.com/assem-ch/django-jet-reboot/issues/54
Issue described here.

https://github.com/django/django/pull/12820/files
This commit removed jQuery from actions.js. Specifically, instead of changing element visibility with the jQ hide()/show() it adds/removes a .hidden class that has a display:none property.

The new class method gets overridden by the preset css display values in changelist.scss. 

I know that gulp needs to be run compile the changes but I'm getting issues getting npm instlal to work on my machine. Can I get someone who has their environment set up to do it?