### PR TITLE
Remove Tracking Pixel

### DIFF
--- a/jet/static/jet/js/src/layout-updaters/branding.js
+++ b/jet/static/jet/js/src/layout-updaters/branding.js
@@ -25,7 +25,4 @@ $(document).ready(function() {
     $('#branding').each(function() {
         new BrandingUpdater($(this)).run();
     });
-    if ($('body.login').length != 0) {
-        $('<img>').attr('src', '//jet.geex-arts.com/ping.gif');
-    }
 });


### PR DESCRIPTION
This seems to be used to ping home, probably done by the author for the purpose of statistics, to know how many projects are using Django Jet, and also to keep some control on who was paying or not paying for the commercial license. I think this ping.gif should be removed.
Aditionally, the server where the image is located is not working, so this is taking 20 secods before the browser blocks the request, which might cause lots of different problems.