### PR TITLE
Check for existence of U+2026 as condition when updating the paginato…

### DIFF
--- a/jet/static/jet/js/src/layout-updaters/paginator.js
+++ b/jet/static/jet/js/src/layout-updaters/paginator.js
@@ -16,9 +16,9 @@ PaginatorUpdater.prototype = {
             if (($node.prev().prop('tagName') == 'A' || $node.prev().prop('tagName') == 'SPAN')
                 && ($node.next().prop('tagName') == 'A' || $node.next().prop('tagName') == 'SPAN')) {
 
-                if ($.trim($node.text()) == '...') {
+                    if ($node.text().trim() == '...' || $node.text().trim() == '…') {
                     $node.wrap($('<span>').addClass('disabled'));
-                } else if ($.trim($node.text()) == '') {
+                } else if ($node.text().trim() == '') {
                     $node.remove();
                 }
             }


### PR DESCRIPTION
Django uses a horizontal ellipsis instead of 3 period when building the paginator. This fix checks for the existence of the ellipsis when updating the paginator layout. This will fix issue #53 .